### PR TITLE
Customize prefix name with an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Then the generator will use those templates to generate scaffold.
 
 #### How to customize your prefix name
 
-Type your command with option --prefix_name="xxxx".
+Type your command with option --prefix_name=xxxx.
 
 If you want change the prefix name 'admin' to 'manager'
 
-e. g. ```bin/rails g admin:scaffold_controller Post title:string content:text published:boolean --prefix_name="manager"```
+e. g. ```bin/rails g admin:scaffold_controller Post title:string content:text published:boolean --prefix_name=manager```
 
 
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Put the '_form.html.erb.erb', 'edit.html.erb.erb', 'index.html.erb.erb', 'new.ht
 
 Then the generator will use those templates to generate scaffold.
 
+#### How to customize your prefix name
+
+Type your command with option --prefix-name="xxxx".
+
+If you want change the prefix name 'admin' to 'manager'
+
+e. g. ```bin/rails g admin:scaffold_controller Post title:string content:text published:boolean --prefix-name="manager"```
 
 
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Then the generator will use those templates to generate scaffold.
 
 #### How to customize your prefix name
 
-Type your command with option --prefix-name="xxxx".
+Type your command with option --prefix_name="xxxx".
 
 If you want change the prefix name 'admin' to 'manager'
 
-e. g. ```bin/rails g admin:scaffold_controller Post title:string content:text published:boolean --prefix-name="manager"```
+e. g. ```bin/rails g admin:scaffold_controller Post title:string content:text published:boolean --prefix_name="manager"```
 
 
 

--- a/lib/generators/admin/scaffold_controller/scaffold_controller_generator.rb
+++ b/lib/generators/admin/scaffold_controller/scaffold_controller_generator.rb
@@ -23,6 +23,9 @@ module Admin
       class_option :html, type: :boolean, default: true,
                    desc: "Generate a scaffold with HTML output"
 
+      class_option :prefix_name, banner: "admin", type: :string, default: "admin",
+                   desc: "Define the prefix of controller"
+
       argument :attributes, type: :array, default: [], banner: "field:type field:type"
 
       def initialize(args, *options) #:nodoc:
@@ -76,7 +79,7 @@ module Admin
       protected
 
       def prefix
-        'admin'
+        options[:prefix_name]
       end
 
       def prefixed_class_name

--- a/test/lib/generators/admin/scaffold_controller_generator_test.rb
+++ b/test/lib/generators/admin/scaffold_controller_generator_test.rb
@@ -116,4 +116,12 @@ class Admin::Generators::ScaffoldControllerGeneratorTest < Rails::Generators::Te
     end
   end
 
+  def test_with_prefix_name
+    run_generator ["User", "name:string", "age:integer", "--prefix_name=manager"]
+    assert_file "app/controllers/manager/users_controller.rb" do |content|
+      assert_match(/Manager\:\:/, content)
+    end
+  end
+
+
 end


### PR DESCRIPTION
If you want change the prefix name 'admin' to 'manager'

e. g. `bin/rails g admin:scaffold_controller Post title:string content:text published:boolean --prefix_name=manager`
