### PR TITLE
preserve capitalization in parent_controller_class_name

### DIFF
--- a/lib/generators/admin/scaffold_controller/scaffold_controller_generator.rb
+++ b/lib/generators/admin/scaffold_controller/scaffold_controller_generator.rb
@@ -106,7 +106,9 @@ module Admin
       end
 
       def parent_controller_class_name
-        options[:parent_controller].capitalize
+        options[:parent_controller][0] = options[:parent_controller][0].capitalize
+        
+        options[:parent_controller]
       end
 
       def prefixed_route_url


### PR DESCRIPTION
I ran into this just now -- my admin parent controller is actually namespaced, so I passed in `--parent_controller=Admin::Base` as my argument, but the generated file has `class Admin::PlansController < Admin::baseController`. 

By only capitalizing the first character without changing the rest of the string, it preserves the behavior from before, but also fixes it for my use case, or any case where someone deliberately capitalizes the argument to parent_controller.
